### PR TITLE
Update ngTranscludeMod.js to be angular 1.5 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ A modification adding features to Angular's ngTransclude
 This branch allows for angular 1.5 multi-slot-transclusion
 
 Here is a plunker displaying all the different types of transclusion options
+
 http://plnkr.co/edit/5XGBEX0muH9CSijMfWsH?p=preview

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ ngTranscludeMod
 ==============
 
 A modification adding features to Angular's ngTransclude
+
+This branch allows for angular 1.5 multi-slot-transclusion
+
+Here is a plunker displaying all the different types of transclusion options
+http://plnkr.co/edit/5XGBEX0muH9CSijMfWsH?p=preview

--- a/ngTranscludeMod.js
+++ b/ngTranscludeMod.js
@@ -1,51 +1,72 @@
-angular.module( 'ngTranscludeMod', [] )
-
-.config(['$provide', function($provide) {
-    $provide.decorator('ngTranscludeDirective', ['$delegate', function($delegate) {
-        // Remove the original directive
-        $delegate.shift();
-        return $delegate;
-    }]);
-}])
-
-.directive( 'ngTransclude', function() {
-    return {
+angular.module('ngTranscludeMod', [])
+    .config([
+      '$provide', function ($provide) {
+        $provide.decorator('ngTranscludeDirective', [
+          '$delegate', function ($delegate) {
+            // Remove the original directive
+            $delegate.shift();
+            return $delegate;
+          }
+        ]);
+      }
+    ])
+    .directive('ngTransclude', function () {
+      return {
         restrict: 'EAC',
-        link: function( $scope, $element, $attrs, controller, $transclude ) {
-            if (!$transclude) {
-                throw minErr('ngTransclude')('orphan',
+        replace:  true,
+        link:     function ($scope, $element, $attrs, controller, $transclude) {
+
+          var types  = ['child', 'parent', 'sibling'];
+          var iScopeType = types[types.indexOf($attrs.ngTransclude)] || undefined;
+
+          if ($attrs.ngTransclude === $attrs.$attr.ngTransclude || iScopeType) {
+            // If the attribute is of the form: `ng-transclude="ng-transclude"`
+            // then treat it like the default
+            $attrs.ngTransclude = '';
+          }
+
+          if (!$transclude) {
+            throw minErr('ngTransclude')('orphan',
                 'Illegal use of ngTransclude directive in the template! ' +
                 'No parent directive that requires a transclusion found. ' +
                 'Element: {0}',
-                startingTag($element) );
-            }
+                startingTag($element));
+          }
 
-            var iScopeType = $attrs['ngTransclude'] || 'sibling';
 
-            switch ( iScopeType ) {
-                case 'sibling':
-                    $transclude( function( clone ) {
-                        $element.empty();
-                        $element.append( clone );
-                    });
-                    break;
-                case 'parent':
-                    $transclude( $scope, function( clone ) {
-                        $element.empty();
-                        $element.append( clone );
-                    });
-                    break;
-                case 'child':
-                    var iChildScope = $scope.$new();
-                    $transclude( iChildScope, function( clone ) {
-                        $element.empty();
-                        $element.append( clone );
-                        $element.on( '$destroy', function() {
-                            iChildScope.$destroy();
-                        });
-                    });
-                    break;
+          //default function for transclude (same as 'sibling')
+          var ngTranscludeScope;
+          // If there is no slot name defined or the slot name is not optional
+          // then transclude the slot
+          var ngTranscludeSlotName  = $attrs.ngTransclude || $attrs.ngTranscludeSlot;
+          var ngTranscludeCloneAttachFn = function (clone) {
+            if (clone.length) {
+              $element.empty();
+              $element.append(clone);
             }
+          };
+
+          switch (iScopeType) {
+            case 'parent':
+              ngTranscludeScope = $scope;
+              break;
+            case 'child':
+              ngTranscludeScope         = $scope.$new();
+              ngTranscludeCloneAttachFn = function (clone) {
+                $element.empty();
+                $element.append(clone);
+                $element.on('$destroy', function () {
+                  ngTranscludeScope.$destroy();
+                });
+              };
+              break;
+          }
+          //Scope cant be null
+          if (ngTranscludeScope) {
+            $transclude(ngTranscludeScope, ngTranscludeCloneAttachFn, null, ngTranscludeSlotName);
+          } else {
+            $transclude(ngTranscludeCloneAttachFn, null, ngTranscludeSlotName);
+          }
         }
-    }
-});
+      };
+    });


### PR DESCRIPTION
Angular 1.5 introduces Multi Slot transclusion, which this version hid. This makes it compatible.
 'parent' or 'child' may not be used as slot names, and to combine 'parent' with a slot name use the ng-transclude-slot attribute
https://github.com/angular/angular.js/commit/a4ada8ba9c4358273575e16778e76446ad080054#comments
https://docs.angularjs.org/api/ng/directive/ngTransclude#multi-slot-transclusion
https://docs.angularjs.org/api/ng/service/$compile#transclusion

Its a little messy and overwhelming but here's a plunker
http://plnkr.co/edit/5XGBEX0muH9CSijMfWsH?p=preview
